### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["api-bindings"]
 [dependencies]
 blkid-sys = "^0.1"
 errno = "^0.2"
-libc = "^0.2"
+libc = "0.2.77"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 categories = ["api-bindings"]
 
 [dependencies]
-blkid-sys = "^0.1"
+blkid-sys = { git = "https://github.com/elastio/blkid-sys", branch = "update-bindgen-version" }
 errno = "^0.2"
 libc = "0.2.77"


### PR DESCRIPTION
1. Update `blkid-sys` to forked version. See explanation [here](https://github.com/elastio/blkid-sys/pull/1#issue-493120556)
2. Update `libc` to latest version